### PR TITLE
Add assert statements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,4 +58,5 @@ shadowJar {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/sunoo/command/AddCommand.java
+++ b/src/main/java/sunoo/command/AddCommand.java
@@ -27,10 +27,13 @@ public class AddCommand extends Command {
      */
     @Override
     public String execute(TaskList tasks) {
+        int numTasksBefore = tasks.getNumTasks();
         String response = Ui.joinLines(
                 "Got it! Ddeonu has added this task for you:",
                 tasks.addTask(taskToAdd).toString(),
                 "Now you have " + tasks.getNumTasks() + " task(s) in the list, hwaiting!");
+        int numTasksAfter = tasks.getNumTasks();
+        assert numTasksBefore + 1 == numTasksAfter;
         return Ui.wrapWithHorizontalLines(response);
     }
 

--- a/src/main/java/sunoo/command/DeleteCommand.java
+++ b/src/main/java/sunoo/command/DeleteCommand.java
@@ -35,11 +35,14 @@ public class DeleteCommand extends Command {
         if (indexToDelete > tasks.getNumTasks()) {
             throw new SunooException("Sorry ENGENE, you don't have that many tasks!");
         }
+        int numTasksBefore = tasks.getNumTasks();
         String response = Ui.joinLines(
                 "Ok, ENGENE! I've removed this task:",
                 tasks.deleteTask(indexToDelete).toString(),
                 "Now you have " + tasks.getNumTasks()
                         + " task(s) in the list left, hwaiting!");
+        int numTasksAfter = tasks.getNumTasks();
+        assert numTasksBefore - 1 == numTasksAfter;
         return Ui.wrapWithHorizontalLines(response);
     }
 

--- a/src/main/java/sunoo/command/MarkCommand.java
+++ b/src/main/java/sunoo/command/MarkCommand.java
@@ -39,6 +39,7 @@ public class MarkCommand extends Command {
         String response = Ui.joinLines(
                 "Nice job, ENGENE! I've marked this task as done:",
                 tasks.getTask(indexToMark).toString());
+        assert tasks.getTask(indexToMark).getCompleteStatus();
         return Ui.wrapWithHorizontalLines(response);
     }
 

--- a/src/main/java/sunoo/command/UnmarkCommand.java
+++ b/src/main/java/sunoo/command/UnmarkCommand.java
@@ -35,10 +35,11 @@ public class UnmarkCommand extends Command {
         if (indexToUnmark > tasks.getNumTasks()) {
             throw new SunooException("Sorry ENGENE, you don't have that many tasks!");
         }
-        tasks.markTask(indexToUnmark);
+        tasks.unmarkTask(indexToUnmark);
         String response = Ui.joinLines(
                 "Ok, ENGENE! I've marked this task as not done yet:",
                 tasks.getTask(indexToUnmark).toString());
+        assert !tasks.getTask(indexToUnmark).getCompleteStatus();
         return Ui.wrapWithHorizontalLines(response);
     }
 

--- a/src/main/java/sunoo/storage/Storage.java
+++ b/src/main/java/sunoo/storage/Storage.java
@@ -34,6 +34,7 @@ public class Storage {
         while (s.hasNextLine()) {
             String taskText = s.nextLine();
             String[] taskParts = taskText.split(" \\| ");
+            assert taskParts.length >= 3;
             boolean isDone;
             switch (taskParts[0]) {
             case "T":
@@ -52,6 +53,7 @@ public class Storage {
                         LocalDateTime.parse(taskParts[4], DateTimeFormatter.ISO_LOCAL_DATE_TIME)));
                 break;
             default:
+                assert false;
                 break;
             }
         }

--- a/src/main/java/sunoo/task/Task.java
+++ b/src/main/java/sunoo/task/Task.java
@@ -65,6 +65,10 @@ public class Task {
         isDone = false;
     }
 
+    public boolean getCompleteStatus() {
+        return isDone;
+    }
+
     /**
      * Returns boolean value of whether the task description contains a keyword.
      *

--- a/src/main/java/sunoo/ui/Sunoo.java
+++ b/src/main/java/sunoo/ui/Sunoo.java
@@ -27,6 +27,7 @@ public class Sunoo {
         } finally {
             Storage.updateTaskListInTxt(tasks);
         }
+        assert response != null;
         return response;
     }
 


### PR DESCRIPTION
Code lacks assert statements.

Assert statements are used to document assumptions that should hold true at parts of the code.

Let's add assert statements at segments of the code where there are changes made to tasks or the task list, or when tasks are read from the data file.